### PR TITLE
Fixes #30226 - Use foreman name to id resolver

### DIFF
--- a/lib/hammer_cli_foreman_ansible.rb
+++ b/lib/hammer_cli_foreman_ansible.rb
@@ -11,6 +11,8 @@ module HammerCLIForemanAnsible
   require 'hammer_cli_foreman_ansible/host'
   require 'hammer_cli_foreman_ansible/hostgroup'
 
+  require 'hammer_cli_foreman_ansible/command_extensions'
+
   HammerCLI::MainCommand.lazy_subcommand(
     'ansible',
     'Manage foreman ansible',

--- a/lib/hammer_cli_foreman_ansible/command_extensions.rb
+++ b/lib/hammer_cli_foreman_ansible/command_extensions.rb
@@ -1,0 +1,1 @@
+require 'hammer_cli_foreman_ansible/command_extensions/resolver'

--- a/lib/hammer_cli_foreman_ansible/command_extensions/resolver.rb
+++ b/lib/hammer_cli_foreman_ansible/command_extensions/resolver.rb
@@ -1,0 +1,15 @@
+module HammerCLIForemanAnsible
+  module ResolverExtension
+    def create_ansible_roles_search_options(options, mode = nil)
+      if defined? HammerCLIKatello::IdResolver
+        create_search_options_without_katello_api(options, api.resource(:ansible_roles), mode)
+      else
+        create_search_options(options, api.resource(:ansible_roles), mode)
+      end
+    end
+  end
+
+  ::HammerCLIForeman::IdResolver.instance_eval do
+    include ResolverExtension
+  end
+end


### PR DESCRIPTION
h-c-katello resolver rewrites the one in h-c-foreman and changes search options to be aligned with Katello API. h-c-f-ansible uses Foreman API for searching, so it doesn't work well when both plugins are installed.

This patch adds compatibility with h-c-katello plugin's resolver.