### PR TITLE
Fixes #33165 - Fix undefined resolver method with katello

### DIFF
--- a/lib/hammer_cli_foreman_ansible/command_extensions/resolver.rb
+++ b/lib/hammer_cli_foreman_ansible/command_extensions/resolver.rb
@@ -1,7 +1,7 @@
 module HammerCLIForemanAnsible
   module ResolverExtension
     def create_ansible_roles_search_options(options, mode = nil)
-      if defined? HammerCLIKatello::IdResolver
+      if self.class.to_s == 'HammerCLIKatello::IdResolver'
         create_search_options_without_katello_api(options, api.resource(:ansible_roles), mode)
       else
         create_search_options(options, api.resource(:ansible_roles), mode)


### PR DESCRIPTION
We include the `ResolverExtensions` in `::HammerCLIForeman::IdResolver`, but `HammerCLIKatello::IdResolver` actually [subclasses](https://github.com/Katello/hammer-cli-katello/blob/master/lib/hammer_cli_katello/id_resolver.rb#L45) it and we get:

```ruby
defined? HammerCLIKatello::IdResolver #=> true
respond_to?(:create_search_options_without_katello_api) #=> false
```
So it seems like we do not need to check for katello methods inside foreman resolver.