### PR TITLE
Fixes #35585 - add ansible_callback_enabled field to InfoCommand on JobTemplate

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -30,6 +30,12 @@ jobs:
           repository: theforeman/hammer-cli-foreman
           ref: master
           path: hammer-cli-foreman
+      - name: Get hammer_cli_foreman_remote_execution
+        uses: actions/checkout@v2
+        with:
+          repository: theforeman/hammer_cli_foreman_remote_execution
+          ref: master
+          path: hammer_cli_foreman_remote_execution
       - name: Get hammer-cli-foreman-ansible
         uses: actions/checkout@v2
         with:
@@ -38,6 +44,7 @@ jobs:
         run: |
           echo "gemspec path: '../hammer-cli', name: 'hammer_cli'" > Gemfile.local.rb
           echo "gemspec path: '../hammer-cli-foreman', name: 'hammer_cli_foreman'" >> Gemfile.local.rb
+          echo "gemspec path: '../hammer_cli_foreman_remote_execution', name: 'hammer_cli_foreman_remote_execution'" >> Gemfile.local.rb
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/hammer_cli_foreman_ansible.gemspec
+++ b/hammer_cli_foreman_ansible.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir['{test}/**/*']
 
   spec.add_dependency 'hammer_cli_foreman', '>= 0.12.0'
+  spec.add_dependency 'hammer_cli_foreman_remote_execution'
 
   spec.add_development_dependency 'rake', '>= 12.3.3'
 end

--- a/lib/hammer_cli_foreman_ansible.rb
+++ b/lib/hammer_cli_foreman_ansible.rb
@@ -3,6 +3,7 @@ module HammerCLIForemanAnsible
   require 'hammer_cli_foreman'
   require 'hammer_cli_foreman/host'
   require 'hammer_cli_foreman/hostgroup'
+  require 'hammer_cli_foreman_remote_execution'
 
   require 'hammer_cli_foreman_ansible/version'
   require 'hammer_cli_foreman_ansible/i18n'
@@ -13,6 +14,8 @@ module HammerCLIForemanAnsible
   require 'hammer_cli_foreman_ansible/hostgroup'
 
   require 'hammer_cli_foreman_ansible/command_extensions'
+
+  HammerCLIForemanRemoteExecution::JobTemplate::InfoCommand.extend_with(HammerCLIForemanAnsible::CommandExtensions::JobTemplate.new)
 
   HammerCLI::MainCommand.lazy_subcommand(
     'ansible',

--- a/lib/hammer_cli_foreman_ansible/command_extensions.rb
+++ b/lib/hammer_cli_foreman_ansible/command_extensions.rb
@@ -1,2 +1,3 @@
 require 'hammer_cli_foreman_ansible/command_extensions/resolver'
 require 'hammer_cli_foreman_ansible/command_extensions/inventory'
+require 'hammer_cli_foreman_ansible/command_extensions/job_template'

--- a/lib/hammer_cli_foreman_ansible/command_extensions/job_template.rb
+++ b/lib/hammer_cli_foreman_ansible/command_extensions/job_template.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module HammerCLIForemanAnsible
+  module CommandExtensions
+    class JobTemplate < HammerCLI::CommandExtensions
+      before_print do |data|
+        unless data['provider_type'] == 'Ansible'
+          data.delete('ansible_callback_enabled')
+        end
+      end
+
+      output do |definition|
+        definition.insert(:before, :description) do
+          field :ansible_callback_enabled, _('Ansible Callback Enabled'), Fields::Boolean
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Modify the `InfoCommand` on `JobTemplate` (located in `hammer_cli_foreman_remote_execution`) by adding the new `ansible_callback_enabled` field.

Requires:
- https://github.com/theforeman/foreman_ansible/pull/572

Some questions regarding this change:
1. Do we need translations here?  (for the `_('Ansible Callback Enabled')`). If so, what is the workflow to add that? 
2. Currently the new `ansible_callback_enabled` field is displayed for all types of providers (both `Ansible` and `Script`), even though we only need it for the `Ansible` provider. Should we display it only for that case? (I'm asking to make sure we need it, since I'm not sure how to implement it).
