### PR TITLE
LoadError: cannot load such file -- coverage_reporter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'gettext', '>= 3.1.3', '< 4.0.0'
 
 group :test do
   gem 'ci_reporter_minitest', '~> 1.0.0', require: false
-  gem 'minitest', '5.14.1'
+  gem 'minitest', '~> 5.18.0'
   gem 'minitest-spec-context'
   gem 'mocha'
   gem 'rake', '~> 10.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -4,13 +4,13 @@ gemspec
 
 # for generating i18n files, gettext > 3.0 dropped ruby 1.8 support
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
+gem 'rake', '~> 10.1.0'
 
 group :test do
   gem 'ci_reporter_minitest', '~> 1.0.0', require: false
-  gem 'minitest', '~> 5.18.0'
+  gem 'minitest', '~> 5.18'
   gem 'minitest-spec-context'
   gem 'mocha'
-  gem 'rake', '~> 10.1.0'
   gem 'simplecov'
   gem 'thor'
 end

--- a/hammer_cli_foreman_ansible.gemspec
+++ b/hammer_cli_foreman_ansible.gemspec
@@ -20,6 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hammer_cli_foreman', '>= 0.12.0'
   spec.add_dependency 'hammer_cli_foreman_remote_execution'
 
-  spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.required_ruby_version = '>= 2.7', '< 3.0'
 end

--- a/hammer_cli_foreman_ansible.gemspec
+++ b/hammer_cli_foreman_ansible.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'hammer_cli_foreman_remote_execution'
 
   spec.add_development_dependency 'rake', '>= 12.3.3'
+  spec.required_ruby_version = '>= 2.7', '< 3.0'
 end


### PR DESCRIPTION
Started facing this error while working on adding ruby v3 support in `hammer-cli-foreman-ansible`. I have made few changes you can see in `Gemfile` and `hammer_cli_foreman_ansible.gemspec`, updates the minitest version and the required ruby version for the same. 

```
$ bundle exec rake test

File /var/log/hammer/hammer.log not writeable, won't log anything to the file!
Traceback (most recent call last):
	7: from /home/akumari/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/minitest-5.18.0/lib/minitest.rb:83:in `block in autorun'
	6: from /home/akumari/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/minitest-5.18.0/lib/minitest.rb:141:in `run'
	5: from /home/akumari/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/minitest-5.18.0/lib/minitest.rb:112:in `load_plugins'
	4: from /home/akumari/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/minitest-5.18.0/lib/minitest.rb:112:in `each'
	3: from /home/akumari/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/minitest-5.18.0/lib/minitest.rb:118:in `block in load_plugins'
	2: from /home/akumari/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/minitest-5.18.0/lib/minitest.rb:118:in `require'
	1: from /home/akumari/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/hammer_cli_foreman-3.6.0/lib/minitest/hammer_coverage_plugin.rb:1:in `<top (required)>'
/home/akumari/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/hammer_cli_foreman-3.6.0/lib/minitest/hammer_coverage_plugin.rb:1:in `require': cannot load such file -- coverage_reporter (LoadError)
rake aborted!
Command failed with status (1): [ruby -I"lib:test:lib" -I"/home/akumari/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rake-10.1.1/lib" "/home/akumari/.rbenv/versions/2.7.6/lib/ruby/gems/2.7.0/gems/rake-10.1.1/lib/rake/rake_test_loader.rb" "test/functional/host_test.rb" "test/functional/hostgroup_test.rb" ]
```
### Configuration
Ruby version: 2.7.6
rbenv version:  1.2.0