### PR TITLE
disable ruby 2.5 tests

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -14,7 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.5
           - 2.7
 
     steps:


### PR DESCRIPTION
hammer dropped 2.5 support in https://github.com/theforeman/hammer-cli/commit/951d3dfcc408955527248ed9e8374486ba0f9335