### PR TITLE
Remove unnecessary api_expects_no_call in tests

### DIFF
--- a/test/functional/host_test.rb
+++ b/test/functional/host_test.rb
@@ -84,8 +84,6 @@ describe 'host' do
         par[:id] == '1'
       end.returns(ansible_roles)
 
-      api_expects_no_call
-
       result = run_cmd(cmd + params)
       assert_cmd(expected_result, result)
     end
@@ -167,8 +165,6 @@ describe 'host' do
         par[:id] == '1'
       end.returns(ansible_roles)
 
-      api_expects_no_call
-
       result = run_cmd(cmd + params)
       assert_cmd(expected_result, result)
     end
@@ -190,8 +186,6 @@ describe 'host' do
       api_expects(:hosts, :ansible_roles) do |par|
         par[:id] == '1'
       end.returns(ansible_roles)
-
-      api_expects_no_call
 
       result = run_cmd(cmd + params)
       assert_cmd(expected_result, result)

--- a/test/functional/hostgroup_test.rb
+++ b/test/functional/hostgroup_test.rb
@@ -84,8 +84,6 @@ describe 'hostgroup' do
         par[:id] == '1'
       end.returns(ansible_roles)
 
-      api_expects_no_call
-
       result = run_cmd(cmd + params)
       assert_cmd(expected_result, result)
     end
@@ -167,8 +165,6 @@ describe 'hostgroup' do
         par[:id] == '1'
       end.returns(ansible_roles)
 
-      api_expects_no_call
-
       result = run_cmd(cmd + params)
       assert_cmd(expected_result, result)
     end
@@ -190,8 +186,6 @@ describe 'hostgroup' do
       api_expects(:hostgroups, :ansible_roles) do |par|
         par[:id] == '1'
       end.returns(ansible_roles)
-
-      api_expects_no_call
 
       result = run_cmd(cmd + params)
       assert_cmd(expected_result, result)


### PR DESCRIPTION
`mocha-2.6.0` added a new deprecation warning for `.expects.never` calls that make our tests fail. Even though there might be a bug in the library itself and we could pin to a previous version, after revisiting these tests, I'd say let's drop unnecessary expectations. If there would be unexpected API call, the test would fail anyway.