### PR TITLE
Fixes #38335 - Adding ansible_diff_mode option to Hammer Job Template Commands

### DIFF
--- a/lib/hammer_cli_foreman_ansible/command_extensions/job_template.rb
+++ b/lib/hammer_cli_foreman_ansible/command_extensions/job_template.rb
@@ -7,6 +7,7 @@ module HammerCLIForemanAnsible
         unless data['provider_type'] == 'Ansible'
           data.delete('ansible_callback_enabled')
           data.delete('ansible_check_mode')
+          data.delete('ansible_diff_mode')
         end
       end
 
@@ -14,6 +15,7 @@ module HammerCLIForemanAnsible
         definition.insert(:before, :description) do
           field :ansible_callback_enabled, _('Ansible Callback Enabled'), Fields::Boolean
           field :ansible_check_mode, _('Ansible Check Mode Enabled'), Fields::Boolean
+          field :ansible_diff_mode, _('Ansible Diff Mode Enabled'), Fields::Boolean
         end
       end
     end


### PR DESCRIPTION
#### Overview of Changes
This PR adds the `--ansible-diff-mode` option to hammer cli for Ansible Job Templates.  See PR https://github.com/theforeman/foreman_ansible/pull/764 for more information.

#### Implementation Considerations

#### Testing Steps
1. Add the changes in https://github.com/theforeman/foreman_ansible/pull/764 to your test environment.
2. Export the "Ansible Roles - Ansible Default" Job Template.
```
hammer job-template export --name "Ansible Roles - Ansible Default" > job_template
```
3. Create a new job template using the exported template with the `--ansible-diff-mode true` argument:
```
# hammer job-template create --ansible-diff-mode true --file job_template --name "Ansible Clone Attempt" --job-category "Ansible Playbook" --provider-type "Ansible"
Job template created
```
4. Run an info command to verify the Ansible Check Mode Enabled flag is set on the new Job Template:
```
# hammer job-template info --id 260
ID:                         260
Name:                       Ansible Clone Attempt
Job Category:               Ansible Playbook
Provider:                   Ansible
Type:                       job_template
Ansible Callback Enabled:   no
Ansible Check Mode Enabled: no
Ansible Diff Mode Enabled:  yes
Description:                
    
Inputs:

...
```

#### Checklists

* [x] I am familiar with the [contributing](https://github.com/theforeman/foreman/blob/develop/CONTRIBUTING.md) guidelines.
* [x] I have added relevant tests for my changes.
* [x] I have updated the documentation accordingly.

#### Additional Notes
### This PR is dependent on:
* [ ] https://github.com/theforeman/foreman_ansible/pull/764
* [ ] https://github.com/theforeman/smart_proxy_ansible/pull/100