### PR TITLE
Relax hammer_cli_foreman dependency to allow 5.x

### DIFF
--- a/hammer_cli_foreman_ansible.gemspec
+++ b/hammer_cli_foreman_ansible.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7', '< 4'
 
-  spec.add_dependency 'hammer_cli_foreman', '~> 3.10'
+  spec.add_dependency 'hammer_cli_foreman', '~> 5.0'
   spec.add_dependency 'hammer_cli_foreman_remote_execution', '~> 0.3'
 end

--- a/hammer_cli_foreman_ansible.gemspec
+++ b/hammer_cli_foreman_ansible.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7', '< 4'
 
-  spec.add_dependency 'hammer_cli_foreman', '~> 5.0'
+  spec.add_dependency 'hammer_cli_foreman', '>= 3.10', '< 6.0'
   spec.add_dependency 'hammer_cli_foreman_remote_execution', '~> 0.3'
 end


### PR DESCRIPTION
## Summary
- Relax the hammer_cli_foreman version constraint from ~> 3.10 to ~> 5.0 to allow compatibility with the upcoming 5.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)